### PR TITLE
add missing prereq declaration from 5.007

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -20,3 +20,4 @@ Dist::Zilla::Plugin::CheckPrereqsIndexed  = 0
 Dist::Zilla::Plugin::PromptIfStale        = 0
 Dist::Zilla::Plugin::Test::ReportPrereqs  = 0
 Dist::Zilla::Plugin::Test::ChangesHasContent = 0
+Dist::Zilla::Plugin::Git::Contributors = 0


### PR DESCRIPTION
fixes travis failures such as https://travis-ci.org/rjbs/Dist-Zilla/builds/52395675
